### PR TITLE
updated PrivateKey/EncryptKey pattern with more secure defaults

### DIFF
--- a/examples/basic.go
+++ b/examples/basic.go
@@ -1,26 +1,36 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
+	"log"
+
 	"github.com/bregydoc/blackholeDB"
 )
 
 func main() {
-	db, err := blackhole.Open(blackhole.DefaultOptions)
+
+	// initialize db options
+	opts := blackhole.DefaultOptions
+
+	// Set PrivateKey. This should come from an ENV or a secret store in the real world
+	opts.PrivateKey, _ = hex.DecodeString("44667768254d593b7ea48c3327c18a651f6031554ca4f5e3e641f6ff1ea72e98")
+
+	db, err := blackhole.Open(opts)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	defer db.Close()
 
 	err = db.Set("answer", []byte("42"))
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	answer, err := db.Get("answer")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	fmt.Println("The answer of the life is: ", string(answer))

--- a/singularity.go
+++ b/singularity.go
@@ -3,20 +3,12 @@ package blackhole
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/md5"
 	"crypto/rand"
-	"encoding/hex"
 	"io"
 )
 
-func createHash(key string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(key))
-	return hex.EncodeToString(hasher.Sum(nil))
-}
-
-func encrypt(data []byte, passphrase string) []byte {
-	block, _ := aes.NewCipher([]byte(createHash(passphrase)))
+func encrypt(data []byte, key []byte) []byte {
+	block, _ := aes.NewCipher(key)
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
 		panic(err.Error())
@@ -29,8 +21,7 @@ func encrypt(data []byte, passphrase string) []byte {
 	return cipherText
 }
 
-func decrypt(data []byte, passphrase string) []byte {
-	key := []byte(createHash(passphrase))
+func decrypt(data []byte, key []byte) []byte {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
The major change here is to how keys are used by the system. This allows for a simpler design internally and puts the expectation on the user to generate a secure 32 byte key before passing in the `Options` for running the DB. 

This PR changes two library files and updates the example file. Below I'll outline my PR file by file:

### dead_star.go

- ADDED `errors` to handle KeyLength checks on initialization of `Open()`
- ADDED a function `func ValidateKey(k []byte) error`, that checks basic settings on a PrivateKey
- REMOVED  `PrivateKey:         "black_hole",` from defaults, defaults should promote safe behavior
- CHANGED `DB.encryptKey` from type `string` to type `[]byte`
- CHANGED `Options.PrivateKey` from type `string` to type `[]byte`

### singularity.go

Now that Options and DB structs already expect a properly formatted 32 byte

- REMOVED `encoding/hex` and `crypto/md5` as they are no longer needed
- REMOVED `createHash` function as it is no longer needed
- UPDATED ` encrypt(data []byte, passphrase string)` to `encrypt(data []byte, key []byte)` 
- UPDATED `encrypt` function now deals with the byte slice directly instead of generating a []byte slice from a hash of a string
- UPDATED ` decrypt(data []byte, passphrase string)` to `decrypt(data []byte, key []byte)` 
- UPDATED `decrypt` function now deals with the byte slice directly instead of generating a []byte slice from a hash of a string

### examples/basic.go

- ADDED `log` and `encoding/hex` packages
- REPLACED `panic` with `log.Fatal` for error handling
- ADDED example of setting a key and adding it to a set of `DefaultOptions` before opening a new DB
