### PR TITLE
added time stamp prefixed random nonce

### DIFF
--- a/singularity.go
+++ b/singularity.go
@@ -1,11 +1,27 @@
 package blackhole
 
 import (
+	"encoding/binary"
+	"time"
+
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"io"
 )
+
+// UnixTimePrefixedNonce takes an int for the nonce size and returns a byte slice of length size.
+// A byte slice is created for the nonce and filled with random data from `crypto/rand`, then the
+// first 4 bytes of the nonce are overwritten with LittleEndian encoding of `time.Now().Unix()`
+// The purpose of this function is to avoid an unlikely collision in randomly generating nonces
+// by prefixing the nonce with time series data.
+func UnixTimePrefixedRandomNonce(size int) []byte {
+	nonce := make([]byte, size)
+	rand.Read(nonce)
+	timeBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(timeBytes, uint64(time.Now().Unix()))
+	copy(nonce, timeBytes[:4])
+	return nonce
+}
 
 func encrypt(data []byte, key []byte) []byte {
 	block, _ := aes.NewCipher(key)
@@ -13,10 +29,9 @@ func encrypt(data []byte, key []byte) []byte {
 	if err != nil {
 		panic(err.Error())
 	}
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
-		panic(err.Error())
-	}
+
+	nonce := UnixTimePrefixedRandomNonce(gcm.NonceSize())
+
 	cipherText := gcm.Seal(nonce, nonce, data, nil)
 	return cipherText
 }


### PR DESCRIPTION
this is addressing the issue raised in #1 by prefixing the random nonce generated with 4 bytes of the `time.Now().Unix()` binary encoded as `LittleEndian` as a time series namespace for the nonce.

This gives each second `1.84E19` possible random keys (`256 bits ^ 8` ). Meaning you'd have to generate `5.1E9` (5,100,000,000) nonces per second to reach a 50% chance of collision based on the birthday paradox.